### PR TITLE
fix: fix self-closing filter box

### DIFF
--- a/components/homepage/Combobox.vue
+++ b/components/homepage/Combobox.vue
@@ -47,18 +47,20 @@ function toggleDropdown() {
 </script>
 
 <template>
-  <div class="relative py-2" @focusin="onFocusIn" @focusout="onFocusOut">
-    <input
-      v-model="searchQuery"
-      type="text"
-      :placeholder="title"
-      :readonly="!!selectedItem"
-      :class="[
-        'w-full px-4 py-2 pr-12 border rounded-md transition-colors duration-200',
-        selectedItem ? 'bg-gray-100 cursor-default text-gray-500' : 'bg-white',
-        'border-gray-300 focus:outline-hidden focus:ring-2 focus:ring-blue-500'
-      ]"
-    />
+  <div class="relative py-2">
+    <div @focusin="onFocusIn" @focusout="onFocusOut">
+      <input
+        v-model="searchQuery"
+        type="text"
+        :placeholder="title"
+        :readonly="!!selectedItem"
+        :class="[
+          'w-full px-4 py-2 pr-12 border rounded-md transition-colors duration-200',
+          selectedItem ? 'bg-gray-100 cursor-default text-gray-500' : 'bg-white',
+          'border-gray-300 focus:outline-hidden focus:ring-2 focus:ring-blue-500'
+        ]"
+      />
+    </div>
     <!-- Clear Button -->
     <button
       v-if="selectedItem"


### PR DESCRIPTION
closes #89 

the problem was that `onFocusIn` was toggling the `isOpen` state before `toggleDropdown` did when one first clicked on the drop-down menu

1. `onFocusIn` changes `isOpen` from `false` to `true`, *then*
2. `toggleDropdown` changes `isOpen` from `true` back to `false`

moving the input box inside a separate `div` with the `onFocus{In,Out}` functionality resolves the issue