### PR TITLE
fix: `onFocusOut` needs to be applied to entire `div`

### DIFF
--- a/components/homepage/Combobox.vue
+++ b/components/homepage/Combobox.vue
@@ -47,8 +47,8 @@ function toggleDropdown() {
 </script>
 
 <template>
-  <div class="relative py-2">
-    <div @focusin="onFocusIn" @focusout="onFocusOut">
+  <div class="relative py-2" @focusout="onFocusOut">
+    <div @focusin="onFocusIn">
       <input
         v-model="searchQuery"
         type="text"


### PR DESCRIPTION
state's a harsh mistress, and for some reason it worked fine locally yesterday :woman_facepalming: 

anyway, the `onFocusOut` needs to be applied to the entire `div` for the menu to properly close after clicking on the button and clicking anywhere else on the page

closes #89 (this time hopefully for good!)