### PR TITLE
feat: use e-mail link for missing maturity evaluation

### DIFF
--- a/components/ProjectQuality.vue
+++ b/components/ProjectQuality.vue
@@ -6,18 +6,29 @@
       </div>
     </div>
     <div class="flex justify-end pb-2 px-4">
-      <span>Maturity: </span
-      ><span
-        v-for="(val, idx) in pprintMaturity"
-        :key="val"
-        :title="title[idx]"
-        :class="`${grayscale[idx]} cursor-help`"
-        >{{ val }}</span
-      >
+      <div v-if="maturity">
+        <span>Maturity: </span
+        ><span
+          v-for="(val, idx) in pprintMaturity"
+          :key="val"
+          :title="title[idx]"
+          :class="`${grayscale[idx]} cursor-help`"
+          >{{ val }}</span
+        >
+      </div>
+      <div v-if="maturity === 0">
+        <span>Request maturity evaluation: </span>
+        <span
+          ><a :href="`${MATURITY_EVALUATION_REQUEST.replaceAll('{name}', project.name)}`"
+            ><FontAwesomeIcon :icon="faEnvelope" class="text-[#707070]" /></a
+        ></span>
+      </div>
     </div>
   </div>
 </template>
 <script lang="ts" setup>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 const props = defineProps<{
   project: ExtendedProject;
 }>();
@@ -40,9 +51,7 @@ if (props.project.lab_status) {
   });
 }
 const maturity = props.project.maturity ?? 0;
-const title = ["Evaluation upon request", "Prototype", "Intermediate", "Mature"];
-const pprintMaturity = ["\u{2753}", "\u{1f95a}", "\u{1f425}", "\u{1f414}"];
-const grayscale = pprintMaturity.map((val, idx) =>
-  (idx > 0 && idx <= maturity) || (idx === 0 && maturity === 0) ? "" : "grayscale-100"
-);
+const title = ["Prototype", "Intermediate", "Mature"];
+const pprintMaturity = ["\u{1f95a}", "\u{1f425}", "\u{1f414}"];
+const grayscale = pprintMaturity.map((val, idx) => (idx <= maturity - 1 ? "" : "grayscale-100"));
 </script>

--- a/utils/vars.ts
+++ b/utils/vars.ts
@@ -9,3 +9,5 @@ export enum PROJECT_STATUS_DESC {
   C4DT_STATUS = "C4DT support status:",
   LAB_STATUS = "Lab support status:"
 }
+export const FACTORY_EMAIL_ADDRESS = "factory@c4dt.org";
+export const MATURITY_EVALUATION_REQUEST = `mailto:${FACTORY_EMAIL_ADDRESS}?subject={name}: maturity evaluation request&body=Dear Factory team, please create a maturity evaluation for '{name}'.`;


### PR DESCRIPTION
replaces "?" by a mailto link for a maturity evaluation request

closes #94 