### PR TITLE
fix "Back" functionality

### DIFF
--- a/components/projects/Tabs.vue
+++ b/components/projects/Tabs.vue
@@ -81,7 +81,7 @@ const router = useRouter();
 const activeTab = ref();
 
 const changeTab = (tabId: string) => {
-  router.push({ query: { section: tabId } });
+  router.replace({ query: { section: tabId } });
   activeTab.value = tabId;
 };
 


### PR DESCRIPTION
this PR fixes the "Back" button functionality on the project pages (cf. #136 )

closes #136 

(the "Back" button as in the navigator's "Back" button, or on their mouse, not the red "Go back" button)