### PR TITLE
improves last commit dates script

### DIFF
--- a/utils/loadData.ts
+++ b/utils/loadData.ts
@@ -34,7 +34,7 @@ export interface ExtendedProject extends Project {
   id: string;
   lab: Lab;
   descriptionDisplay: string;
-  status: int;
+  status: number;
   c4dt_status?: PROJECT_C4DT_STATUS;
   lab_status?: PROJECT_LAB_STATUS;
 }
@@ -123,7 +123,7 @@ async function loadLabProjects(
     project.logo = project.logo || lab.logo || "https://c4dt.epfl.ch/wp-content/themes/epfl/assets/svg/epfl-logo.svg";
     let c4dt_status: PROJECT_C4DT_STATUS | undefined = undefined;
     let lab_status: PROJECT_LAB_STATUS | undefined = undefined;
-    let status: int;
+    let status: number;
     if (project.incubator?.type === "incubated" || project.incubator?.type === "incubated_market") {
       c4dt_status = PROJECT_C4DT_STATUS.ACTIVE;
       status = 0;

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -39,9 +39,33 @@ interface GitHubCommit {
 }
 
 async function getGithubOrgLastCommitDate(orgName: string): Promise<string | undefined> {
-  console.log(`getGithubOrgLastCommitDate(${orgName}) is coming soon!`);
-  return;
+  const reposURL = `https://api.github.com/orgs/${orgName}/repos?per_page=1&sort=updated&direction=desc`;
+  try {
+    const response = await fetch(reposURL, {
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        // Ensure GITHUB_TOKEN is set in your environment
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN ?? ""}`
+      }
+    });
+    if (!response.ok) {
+      console.error(`Failed to get repos for: ${orgName}. HTTP status: ${response.status}`);
+      return;
+    }
+    const lastCommitDate = (await response.json())[0]?.pushed_at;
+    if (!lastCommitDate) {
+      console.error(`Last repo in org ${orgName} Doesn't have any commits.`);
+      return;
+    }
+
+    return lastCommitDate.split("T")[0];
+  } catch (error) {
+    console.error(`Error fetching repos for org: ${orgName}`);
+    console.error(error);
+    return;
+  }
 }
+
 async function getGithubProjectLastCommitDate(orgName: string, repoName: string): Promise<string | undefined> {
   const commitsURL = `https://api.github.com/repos/${orgName}/${repoName}/commits?per_page=1`;
 

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -122,13 +122,14 @@ async function updateLastCommitDate(): Promise<void> {
     const labProjects = await readProjectsFromFile(projectsPath);
 
     for (const [projectId, project] of Object.entries(labProjects.projects)) {
-      const gitUrl = project.code?.url;
-      if (!gitUrl) {
-        console.warn(`No repository URL found for project: ${projectId}`);
-        continue; // Skip if no repository URL is provided
+      if (!project.code) {
+        continue;
       }
-
-      const lastCommitDate = await getProjectLastCommitDate(gitUrl);
+      if (!project.code.url) {
+        console.warn(`No repository URL found for project: ${projectId}`);
+        continue;
+      }
+      const lastCommitDate = await getProjectLastCommitDate(project.code.url);
       if (!lastCommitDate) {
         continue;
       }

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -105,11 +105,32 @@ async function getGithubProjectLastCommitDate(orgName: string, repoName: string)
 }
 
 async function getGitlabOrgLastCommitDate(orgName: string): Promise<string | undefined> {
-  console.log(`getGitlabOrgLastCommitDate(${orgName}) is coming soon!`);
-  return;
+  const reposURL = `https://gitlab.com/api/v4/groups/${orgName}/projects?per_page=1&order_by=last_activity_at`;
+  try {
+    const response = await fetch(reposURL, {
+      headers: {
+        Accept: "application/json"
+      }
+    });
+    if (!response.ok) {
+      console.error(`Failed to get repos for: ${orgName}. HTTP status: ${response.status}`);
+      return;
+    }
+    const lastCommitDate = (await response.json())[0]?.last_activity_at;
+    if (!lastCommitDate) {
+      console.error(`Last repo in org ${orgName} doesn't have any commits.`);
+      return;
+    }
+
+    return lastCommitDate.split("T")[0];
+  } catch (error) {
+    console.error(`Error fetching repos for org: ${orgName}`);
+    console.error(error);
+    return;
+  }
 }
+
 async function getGitlabProjectLastCommitDate(orgName: string, repoName: string): Promise<string | undefined> {
-  console.log("Working...");
   const commitsURL = `https://gitlab.com/api/v4/projects/${orgName}%2F${repoName}/repository/commits?per_page=1`;
   const resp = await fetch(commitsURL, {
     headers: {

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -108,9 +108,25 @@ async function getGitlabOrgLastCommitDate(orgName: string): Promise<string | und
   console.log(`getGitlabOrgLastCommitDate(${orgName}) is coming soon!`);
   return;
 }
-async function getGitlabProjectLastCommitDate(orgName: string, projectName: string): Promise<string | undefined> {
-  console.log(`getGitlabProjectLastCommitDate(${orgName}, ${projectName}) is coming soon!`);
-  return;
+async function getGitlabProjectLastCommitDate(orgName: string, repoName: string): Promise<string | undefined> {
+  console.log("Working...");
+  const commitsURL = `https://gitlab.com/api/v4/projects/${orgName}%2F${repoName}/repository/commits?per_page=1`;
+  const resp = await fetch(commitsURL, {
+    headers: {
+      Accept: "application/json"
+    }
+  });
+  if (!resp.ok) {
+    throw new Error(`GitLab API error: ${resp.status} ${resp.statusText}`);
+  }
+
+  const commits = await resp.json();
+  if (commits.length === 0) {
+    console.error(`No commits found for: ${orgName}/${repoName}.`);
+    return;
+  }
+
+  return commits[0].committed_date.split("T")[0];
 }
 
 /**

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -38,7 +38,7 @@ interface GitHubCommit {
   };
 }
 
-async function getGithubProjectLastCommitDate(orgName: string, repoName: string): Promise<string | null> {
+async function getGithubProjectLastCommitDate(orgName: string, repoName: string): Promise<string | undefined> {
   const commitsURL = `https://api.github.com/repos/${orgName}/${repoName}/commits?per_page=1`;
 
   try {
@@ -52,27 +52,27 @@ async function getGithubProjectLastCommitDate(orgName: string, repoName: string)
 
     if (!response.ok) {
       console.error(`Failed to get commits for: ${orgName}/${repoName}. HTTP status: ${response.status}`);
-      return null;
+      return;
     }
 
     const commits = (await response.json()) as GitHubCommit[];
 
     if (!Array.isArray(commits) || commits.length === 0) {
       console.error(`No commits found for: ${orgName}/${repoName}.`);
-      return null;
+      return;
     }
 
     const lastCommitDate = commits[0]?.commit?.author?.date;
     if (!lastCommitDate) {
       console.error(`Could not retrieve commit date from: ${orgName}/${repoName}`);
-      return null;
+      return;
     }
 
     return lastCommitDate.split("T")[0];
   } catch (error) {
     console.error(`Error fetching commit for repo: ${orgName}/${repoName}`);
     console.error(error);
-    return null;
+    return;
   }
 }
 
@@ -80,7 +80,7 @@ async function getGithubProjectLastCommitDate(orgName: string, repoName: string)
  * Fetches the latest commit date in YYYY-MM-DD format from the provided GitHub repository URL.
  * Returns null if the data cannot be retrieved for any reason.
  */
-async function getProjectLastCommitDate(gitRepo: string): Promise<string | null> {
+async function getProjectLastCommitDate(gitRepo: string): Promise<string | undefined> {
   const url = new URL(gitRepo);
 
   const repoService = url.host;
@@ -88,11 +88,11 @@ async function getProjectLastCommitDate(gitRepo: string): Promise<string | null>
 
   if (repoService !== "github.com" && repoService !== "gitlab.com") {
     console.error(`Unsupported repository service: ${repoService}. Only GitHub and GitLab are supported.`);
-    return null;
+    return;
   }
   if (pathParts.length === 0 || pathParts.length > 2) {
     console.error(`Unrecognizable  URL: ${gitRepo}. Ensure it follows "https://github.com/owner/repo" format.`);
-    return null;
+    return;
   }
   if (pathParts.length !== 2 || repoService !== "github.com") {
     console.error("Case not handled yet!");

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -38,6 +38,10 @@ interface GitHubCommit {
   };
 }
 
+async function getGithubOrgLastCommitDate(orgName: string): Promise<string | undefined> {
+  console.log(`getGithubOrgLastCommitDate(${orgName}) is coming soon!`);
+  return;
+}
 async function getGithubProjectLastCommitDate(orgName: string, repoName: string): Promise<string | undefined> {
   const commitsURL = `https://api.github.com/repos/${orgName}/${repoName}/commits?per_page=1`;
 
@@ -76,6 +80,15 @@ async function getGithubProjectLastCommitDate(orgName: string, repoName: string)
   }
 }
 
+async function getGitlabOrgLastCommitDate(orgName: string): Promise<string | undefined> {
+  console.log(`getGitlabOrgLastCommitDate(${orgName}) is coming soon!`);
+  return;
+}
+async function getGitlabProjectLastCommitDate(orgName: string, projectName: string): Promise<string | undefined> {
+  console.log(`getGitlabProjectLastCommitDate(${orgName}, ${projectName}) is coming soon!`);
+  return;
+}
+
 /**
  * Fetches the latest commit date in YYYY-MM-DD format from the provided GitHub repository URL.
  * Returns null if the data cannot be retrieved for any reason.
@@ -94,11 +107,17 @@ async function getProjectLastCommitDate(gitRepo: string): Promise<string | undef
     console.error(`Unrecognizable  URL: ${gitRepo}. Ensure it follows "https://github.com/owner/repo" format.`);
     return;
   }
-  if (pathParts.length !== 2 || repoService !== "github.com") {
-    console.error("Case not handled yet!");
-    return null;
+
+  switch (`${repoService},${pathParts.length}`) {
+    case "github.com,1":
+      return await getGithubOrgLastCommitDate(pathParts[0]);
+    case "github.com,2":
+      return await getGithubProjectLastCommitDate(pathParts[0], pathParts[1]);
+    case "gitlab.com,1":
+      return await getGitlabOrgLastCommitDate(pathParts[0]);
+    case "gitlab.com,2":
+      return await getGitlabProjectLastCommitDate(pathParts[0], pathParts[1]);
   }
-  return await getGithubProjectLastCommitDate(pathParts[0], pathParts[1]);
 }
 
 /**

--- a/utils/updateLastCommitDate.ts
+++ b/utils/updateLastCommitDate.ts
@@ -39,7 +39,7 @@ interface GitHubCommit {
 }
 
 async function getGithubOrgLastCommitDate(orgName: string): Promise<string | undefined> {
-  const reposURL = `https://api.github.com/orgs/${orgName}/repos?per_page=1&sort=updated&direction=desc`;
+  const reposURL = `https://api.github.com/orgs/${orgName}/repos?per_page=1&sort=pushed&direction=desc`;
   try {
     const response = await fetch(reposURL, {
       headers: {


### PR DESCRIPTION
## Features

closes #126 
- [x] if it points to an organization, e.g., github.com/claimchain, go through all repos and get the most recent commit date
- [x] if there is no code, skip it, e.g., tandem_monero
- [x] not a github repo, like https://gitlab.com/objectifsecurite/ophcrack, skip it (or look if Claude/ChatGPT comes up with an easy-to use code), else skip it

In addition to 
- [x] Handle gitlab project link
- [x] Handle gitlab organization link
- [x] Skip projects with no code block, but raise attention if block exists, with no link. 

P.S. The work is divided into 9 commits. Each commit has a descriptive message


## Output of the script

Here's how the current output looks like: 

```
Unsupported repository service: c4science.ch. Only GitHub and GitLab are supported.
Unrecognizable  URL: https://github.com/dedis/cothority/tree/main/calypso. Ensure it follows "https://github.com/owner/repo" format.
Unrecognizable  URL: https://github.com/dedis/cothority/tree/main/evoting. Ensure it follows "https://github.com/owner/repo" format.
Unsupported repository service: ivrl.epfl.ch. Only GitHub and GitLab are supported.
Unsupported repository service: www.epfl.ch. Only GitHub and GitLab are supported.
Unsupported repository service: code.google.com. Only GitHub and GitLab are supported.
Unrecognizable  URL: https://github.com/c4dt/dp3t-app-android-ch/tree/microg-nearby. Ensure it follows "https://github.com/owner/repo" format.
No repository URL found for project: ai-data-platform-v1
No repository URL found for project: ai-data-platform-v2
Unrecognizable  URL: https://github.com/NEU-SNS/wehe-py3/tree/wehe+Y. Ensure it follows "https://github.com/owner/repo" format.
Unsupported repository service: www.epfl.ch. Only GitHub and GitLab are supported.
Unsupported repository service: www.epfl.ch. Only GitHub and GitLab are supported.
Checked and updated 211 projects.
```