### PR TITLE
fix: use unique identifier for input element/label

### DIFF
--- a/components/homepage/Combobox.vue
+++ b/components/homepage/Combobox.vue
@@ -50,11 +50,11 @@ function onFocusOut(e: FocusEvent) {
 </script>
 
 <template>
-  <label for="searchInput">Filter by {{ title.toLowerCase() }}</label>
+  <label :for="`searchInput${title}`">Filter by {{ title.toLowerCase() }}</label>
   <div ref="combobox" class="py-2" @focusout="onFocusOut">
     <div class="epfl-input justify-end-safe flex">
       <input
-        id="searchInput"
+        :id="`searchInput${title}`"
         v-model="searchQuery"
         type="text"
         :placeholder="title"

--- a/components/homepage/mutliSelectCombobox.vue
+++ b/components/homepage/mutliSelectCombobox.vue
@@ -55,7 +55,7 @@ defineExpose({ clearAll });
 </script>
 
 <template>
-  <label for="searchInput">Filter by {{ title.toLowerCase() }}</label>
+  <label :for="`searchInput${title}`">Filter by {{ title.toLowerCase() }}</label>
   <div ref="multiSelectCombobox" class="py-2" @focusout="onFocusOut">
     <div class="justify-end-safe epfl-input flex">
       <div class="flex w-9/10 flex-wrap overflow-clip py-2 pl-4" tabindex="-1" @focusin="onFocusIn">
@@ -70,7 +70,7 @@ defineExpose({ clearAll });
           </span>
         </div>
         <input
-          id="searchInput"
+          :id="`searchInput${title}`"
           v-model="searchQuery"
           type="text"
           :placeholder="selectedItems.length ? '' : title"


### PR DESCRIPTION
previously they all shared the same identifier, the only reason it "looks" right is because the code is evaluated in the right order, but this would mess up screen readers pretty badly