### PR TITLE
feat: use grayed-out icons instead of disappearing icons

### DIFF
--- a/components/InfoIcons.vue
+++ b/components/InfoIcons.vue
@@ -6,22 +6,19 @@
       :to="{ name: 'projects-id', params: { id: project.id }, query: { section: TAB_IDS.PAPERS } }"
       ><FontAwesomeIcon :icon="faFile" class="fa-2x"
     /></NuxtLink>
+    <FontAwesomeIcon v-else :icon="faFile" class="fa-2x text-[#c1c1c1]" />
     <NuxtLink
       v-if="articles"
       :class="iconClass"
       :to="{ name: 'projects-id', params: { id: project.id }, query: { section: TAB_IDS.ARTICLES } }"
       ><FontAwesomeIcon :icon="faNewspaper" class="fa-2x"
     /></NuxtLink>
-    <div v-if="projectInformationIcons.length" class="flex flex-nowrap space-x-4">
-      <a
-        v-for="info in projectInformationIcons"
-        :key="info.url"
-        :href="info.url"
-        :class="iconClass"
-        :aria-label="info.label"
-      >
+    <FontAwesomeIcon v-else :icon="faNewspaper" class="fa-2x text-[#c1c1c1]" />
+    <div v-for="info in projectInformationIcons" :key="info" class="flex flex-nowrap space-x-4">
+      <a v-if="info.url" :key="info.url" :href="info.url" :class="iconClass" :aria-label="info.label">
         <FontAwesomeIcon :icon="info.icon" class="fa-2x" />
       </a>
+      <FontAwesomeIcon v-else :icon="info.icon" class="fa-2x text-[#c1c1c1]" />
     </div>
   </div>
 </template>
@@ -50,6 +47,11 @@ const projectInformationIcons = computed(() => {
       icon: faHome,
       label: "Project Homepage"
     });
+  } else {
+    icons.push({
+      url: "",
+      icon: faHome
+    });
   }
 
   if (project.code) {
@@ -58,6 +60,11 @@ const projectInformationIcons = computed(() => {
       icon: project.code.type.toLowerCase().includes("github") ? faGithub : faCode,
       label: "Source Code"
     });
+  } else {
+    icons.push({
+      url: "",
+      icon: faCode
+    });
   }
 
   if (project.contacts && project.contacts.length) {
@@ -65,6 +72,11 @@ const projectInformationIcons = computed(() => {
       url: `mailto:${project.contacts.map((contact) => contact.email).join(",")}`,
       icon: faEnvelope,
       label: "Contact"
+    });
+  } else {
+    icons.push({
+      url: "",
+      icon: faEnvelope
     });
   }
 

--- a/components/homepage/CarouselItem.vue
+++ b/components/homepage/CarouselItem.vue
@@ -30,7 +30,7 @@ const project = props.project;
       </div>
     </NuxtLink>
     <!-- Icons Container -->
-    <div class="mt-auto flex justify-end pr-4 pb-4">
+    <div class="mt-auto flex justify-end overflow-clip pr-4 pb-4">
       <InfoIcons :project="project" />
     </div>
   </div>

--- a/components/homepage/ProjectCard.vue
+++ b/components/homepage/ProjectCard.vue
@@ -27,9 +27,9 @@
             </span>
           </div>
         </div>
-        <!-- Icons on the Right -->
-        <InfoIcons :project="project" />
+        <InfoIcons :project="project" class="hidden sm:flex" />
       </div>
+      <InfoIcons :project="project" class="mt-4 block sm:hidden" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
up for debate: I prefer grayed-out information, as

- this let's us quickly see what information is missing for each project
- it's less confusing for the user (explicit is better than implicit - "Why is the icon on this project but not on the other?" does not necessarily lead to "That information must be missing!" whereas grayed-out is more intuitive imho)

also some repositioning/fixes for smaller screens