### PR TITLE
fix broken display of support options in filter box

### DIFF
--- a/components/homepage/DropdownList.vue
+++ b/components/homepage/DropdownList.vue
@@ -15,11 +15,9 @@ defineProps<{
         v-for="name in filteredList"
         :key="name"
         class="epfl-option"
-        :title="name"
         @mousedown.prevent="selectFunc(name)"
-      >
-        {{ name }}
-      </li>
+        v-html="name"
+      />
     </ul>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type Combobox from "~/components/homepage/Combobox.vue";
 import type MutliSelectCombobox from "~/components/homepage/mutliSelectCombobox.vue";
+import { icon } from "@fortawesome/fontawesome-svg-core";
 
 const selectedStatus = ref("");
 const selectedLab = ref("");
@@ -22,9 +23,9 @@ provide("addTag", addTag);
 const searchQuery = useSearchQuery();
 
 const pprintStatus = [
-  `${PROJECT_STATUS_DESC.C4DT_STATUS} ${PROJECT_C4DT_STATUS.ACTIVE}`,
-  `${PROJECT_STATUS_DESC.C4DT_STATUS} ${PROJECT_C4DT_STATUS.RETIRED}`,
-  `${PROJECT_STATUS_DESC.LAB_STATUS} ${PROJECT_LAB_STATUS.ACTIVE}`
+  `${PROJECT_C4DT_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
+  `${PROJECT_C4DT_STATUS.RETIRED} (<span class='text-[#707070]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.RETIRED]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
+  `${PROJECT_LAB_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_LAB_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.LAB_STATUS}`
 ];
 
 const labsFilter = ref<InstanceType<typeof Combobox>>();


### PR DESCRIPTION
from what I understand, using `v-html` makes this slightly less secure, as the HTML is not escaped by Vue.js like this

but I think it's OK, as

- one part comes from the files that we are reviewing
- one part comes from the official Fontawesome package, which is likely well-reviewed
- the website does not handle any secret data that could be leaked in case of an XSS attack

closes #194 