### PR TITLE
improve sort order

### DIFF
--- a/components/homepage/Combobox.vue
+++ b/components/homepage/Combobox.vue
@@ -58,6 +58,7 @@ function onFocusOut(e: FocusEvent) {
   <div ref="combobox" class="py-2" @focusout="onFocusOut">
     <div class="epfl-input flex">
       <input
+        v-if="!selectedItem"
         :id="`searchInput${title}`"
         v-model="searchQuery"
         type="text"
@@ -65,6 +66,13 @@ function onFocusOut(e: FocusEvent) {
         :readonly="!!selectedItem"
         class="w-9/10 truncate py-2 pl-4 focus:outline-hidden"
         @focusin="onFocusIn"
+      />
+      <div
+        v-else
+        :id="`searchInput${title}`"
+        class="w-9/10 truncate py-2 pl-4 focus:outline-hidden"
+        @focusin="onFocusIn"
+        v-html="selectedItem"
       />
       <div class="w-1/10 overflow-clip py-2">
         <ClearButton v-if="searchQuery && !selectedItem" :clear-func="clearInput" aria-label="Clear search query" />


### PR DESCRIPTION
- better sorting (see #116 )
- fix display of chosen support filter label

for the `sortKey`, I choose 8, 4, 2, 1 to avoid collisions, e.g. for 4, 3, 2, 1 for C4DT active/lab active/C4DT inactive/lab inactive, C4DT active + lab inactive = 5 = lab active + C4DT inactive, whereas with 8, 4, 2, 1 the possible combinations add to 12, 9, 6 and 3 (maybe I overthought this...)

closes #116 