### PR TITLE
support filter fixes

### DIFF
--- a/components/homepage/Combobox.vue
+++ b/components/homepage/Combobox.vue
@@ -58,6 +58,7 @@ function onFocusOut(e: FocusEvent) {
   <div ref="combobox" class="py-2" @focusout="onFocusOut">
     <div class="epfl-input flex">
       <input
+        v-if="!selectedItem"
         :id="`searchInput${title}`"
         v-model="searchQuery"
         type="text"
@@ -65,6 +66,13 @@ function onFocusOut(e: FocusEvent) {
         :readonly="!!selectedItem"
         class="w-9/10 truncate py-2 pl-4 focus:outline-hidden"
         @focusin="onFocusIn"
+      />
+      <div
+        v-else
+        :id="`searchInput${title}`"
+        class="w-9/10 truncate py-2 pl-4 focus:outline-hidden"
+        @focusin="onFocusIn"
+        v-html="selectedItem"
       />
       <div class="w-1/10 overflow-clip py-2">
         <ClearButton v-if="searchQuery && !selectedItem" :clear-func="clearInput" aria-label="Clear search query" />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type Combobox from "~/components/homepage/Combobox.vue";
 import type MutliSelectCombobox from "~/components/homepage/mutliSelectCombobox.vue";
-import { icon } from "@fortawesome/fontawesome-svg-core";
 
 const selectedStatus = ref("");
 const selectedLab = ref("");
@@ -21,12 +20,6 @@ function addTag(tag: string) {
 provide("addTag", addTag);
 
 const searchQuery = useSearchQuery();
-
-const pprintStatus = [
-  `${PROJECT_C4DT_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
-  `${PROJECT_C4DT_STATUS.RETIRED} (<span class='text-[#707070]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.RETIRED]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
-  `${PROJECT_LAB_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_LAB_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.LAB_STATUS}`
-];
 
 const labsFilter = ref<InstanceType<typeof Combobox>>();
 const categoriesFilter = ref<InstanceType<typeof Combobox>>();
@@ -62,7 +55,9 @@ const projectTags: string[] = Array.from(new Set(projects.value.flatMap((project
 const filteredProjects = computed(() => {
   return projects.value.filter((project) => {
     return (
-      (selectedStatus.value === "" || project.status === pprintStatus.indexOf(selectedStatus.value)) &&
+      (selectedStatus.value === "" ||
+        selectedStatus.value === PPRINTED_C4DT_STATUS[project.c4dt_status] ||
+        selectedStatus.value === PPRINTED_LAB_STATUS[project.lab_status]) &&
       (selectedTag.value === "" || project.tags.includes(selectedTag.value)) &&
       (selectedLab.value === "" || project.lab.name === selectedLab.value.split(" - ")[1]) &&
       (selectedCategory.value === "" || project.categories.includes(selectedCategory.value)) &&
@@ -130,7 +125,7 @@ watch(filteredProjects, () => {
                   ref="statusFilter"
                   v-model="selectedStatus"
                   title="Support"
-                  :item-list="pprintStatus"
+                  :item-list="PPRINTED_STATUS"
                 />
                 <homepageCombobox
                   ref="categoriesFilter"

--- a/utils/vars.ts
+++ b/utils/vars.ts
@@ -1,4 +1,5 @@
 import { faCircleCheck, faCirclePause, faEllipsis } from "@fortawesome/free-solid-svg-icons";
+import { icon } from "@fortawesome/fontawesome-svg-core";
 
 export enum PROJECT_C4DT_STATUS {
   ACTIVE = "Active",
@@ -19,6 +20,18 @@ export const PROJECT_STATUS_ICONS = {
   [PROJECT_C4DT_STATUS.INACTIVE]: faEllipsis,
   [PROJECT_LAB_STATUS.ACTIVE]: faCircleCheck,
   [PROJECT_LAB_STATUS.UNKNOWN]: faEllipsis
+};
+export const PPRINTED_STATUS = [
+  `${PROJECT_C4DT_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
+  `${PROJECT_C4DT_STATUS.RETIRED} (<span class='text-[#707070]'>${icon(PROJECT_STATUS_ICONS[PROJECT_C4DT_STATUS.RETIRED]).html[0]}</span>) ${PROJECT_STATUS_DESC.C4DT_STATUS}`,
+  `${PROJECT_LAB_STATUS.ACTIVE} (<span class='text-[#b51f1f]'>${icon(PROJECT_STATUS_ICONS[PROJECT_LAB_STATUS.ACTIVE]).html[0]}</span>) ${PROJECT_STATUS_DESC.LAB_STATUS}`
+];
+export const PPRINTED_C4DT_STATUS = {
+  [PROJECT_C4DT_STATUS.ACTIVE]: PPRINTED_STATUS[0],
+  [PROJECT_C4DT_STATUS.RETIRED]: PPRINTED_STATUS[1]
+};
+export const PPRINTED_LAB_STATUS = {
+  [PROJECT_LAB_STATUS.ACTIVE]: PPRINTED_STATUS[2]
 };
 export const FACTORY_EMAIL_ADDRESS = "factory@c4dt.org";
 export const MATURITY_EVALUATION_REQUEST = `mailto:${FACTORY_EMAIL_ADDRESS}?subject={name}: maturity evaluation request&body=Dear Factory team, please create a maturity evaluation for '{name}'.`;


### PR DESCRIPTION
- better sorting (see #116 )
- fix display of chosen support filter label
- proper filtering of projects that are both supported by C4DT AND the lab (see #211 )

for the `sortKey`, I choose 8, 4, 2, 1 to avoid collisions, e.g. for 4, 3, 2, 1 for C4DT active/lab active/C4DT inactive/lab inactive, C4DT active + lab inactive = 5 = lab active + C4DT inactive, whereas with 8, 4, 2, 1 the possible combinations add to 12, 9, 6 and 3 (maybe I overthought this...)

closes #116 
closes #211 